### PR TITLE
Fix bug where starting with --ip causes immediate exit

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -124,6 +124,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 				return err
 			}
 		}
+		sm.Wait()
 	}
 
 	return nil


### PR DESCRIPTION
Fixes a bug where when creating a server with manually specified IPs (instead of `--cloud`), the server would immediately exit.