### PR TITLE
Adds MSS rule to prevent failed SSL handshakes

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -317,12 +317,9 @@ func (srv *Server) StartIptables() error {
 
 	err = srv.iptablesMssRule(true)
 	if err != nil {
-		if err := srv.iptablesSnatRule(false); err != nil {
-			return fmt.Errorf("failed to add MSS rule: %v", err)
-		}
-		if err := srv.iptablesInputFwmarkRule(false); err != nil {
-			return fmt.Errorf("failed to add MSS rule: %v", err)
-		}
+		srv.iptablesSnatRule(false)
+		srv.iptablesInputFwmarkRule(false)
+		return fmt.Errorf("failed to add MSS rule: %v", err)
 	}
 
 	return nil

--- a/lib/server.go
+++ b/lib/server.go
@@ -317,9 +317,12 @@ func (srv *Server) StartIptables() error {
 
 	err = srv.iptablesMssRule(true)
 	if err != nil {
-		err = srv.iptablesSnatRule(false)
-		srv.iptablesInputFwmarkRule(false)
-		return fmt.Errorf("failed to add MSS rule: %v", err)
+		if err := srv.iptablesSnatRule(false); err != nil {
+			return fmt.Errorf("failed to add MSS rule: %v", err)
+		}
+		if err := srv.iptablesInputFwmarkRule(false); err != nil {
+			return fmt.Errorf("failed to add MSS rule: %v", err)
+		}
 	}
 
 	return nil

--- a/lib/server.go
+++ b/lib/server.go
@@ -286,6 +286,23 @@ func (srv *Server) iptablesSnatRule(enabled bool) error {
 	}
 }
 
+// iptablesMssRule adds or removes the FORWARD chain rule for TCP MSS adjustment
+func (srv *Server) iptablesMssRule(enabled bool) error {
+	rule := []string{
+		"-p", "tcp",
+		"--tcp-flags", "SYN,RST", "SYN",
+		"-j", "TCPMSS",
+		"--set-mss", "1160",
+		"-m", "comment", "--comment", fmt.Sprintf("vprox mss rule for %s", srv.Ifname()),
+	}
+
+	if enabled {
+		return srv.Ipt.AppendUnique("filter", "FORWARD", rule...)
+	} else {
+		return srv.Ipt.Delete("filter", "FORWARD", rule...)
+	}
+}
+
 func (srv *Server) StartIptables() error {
 	err := srv.iptablesInputFwmarkRule(true)
 	if err != nil {
@@ -296,6 +313,13 @@ func (srv *Server) StartIptables() error {
 	if err != nil {
 		srv.iptablesInputFwmarkRule(false)
 		return fmt.Errorf("failed to add SNAT rule: %v", err)
+	}
+
+	err = srv.iptablesMssRule(true)
+	if err != nil {
+		err = srv.iptablesSnatRule(false)
+		srv.iptablesInputFwmarkRule(false)
+		return fmt.Errorf("failed to add MSS rule: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
This adds a MSS that intercepts TCP handshake packets and sets MSS to 1160, ensuring packets stay within Wireguard MTU limits after encapsulation (typically 1420 bytes for Wireguard).

In this case, certain SSL handshakes were failing because packets were too large for the Wireguard tunnel, causing fragmentation and reordering that disrupted the SSL negotiation, causing the connection to hang.

A potential side effect is greater overhead resulting in increased latency. I have no evidence this is the case here. It solves the issue we are observing with hanging connections. 