### PR TITLE
Tighten up client side healthchecking and timeouts

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -23,9 +23,13 @@ import (
 // (note that this dosen't include the time spent checking)
 const healthCheckInterval = 2 * time.Second
 
-const healthCheckTimeout = 5 * time.Second // how long do we wait before the health check times out?
-const reconnectInterval = 2 * time.Second  // when we're unhealthy, how frequently do we try reconnecting?
-const dialRetryTimeout = 10 * time.Second  // how long to retry on ECONNREFUSED
+// how long do we wait for the tunnel's first handshake before giving up?
+// this spans several of WireGuard's REKEY_TIMEOUT (5s) handshake retries, so
+// that a single dropped handshake packet doesn't fail the connection.
+const initialHandshakeTimeout = 20 * time.Second
+
+const reconnectInterval = 2 * time.Second // when we're unhealthy, how frequently do we try reconnecting?
+const dialRetryTimeout = 10 * time.Second // how long to retry on ECONNREFUSED
 
 // dialWithRetry retries TCP connections on ECONNREFUSED up to dialRetryTimeout.
 func dialWithRetry(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -137,8 +141,8 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	}()
 
 	log.Println("Connected...")
-	if !client.CheckConnection(healthCheckTimeout, ctx) {
-		return fmt.Errorf("connection failed initial healthcheck after %v", healthCheckTimeout)
+	if !client.WaitForHandshake(initialHandshakeTimeout, ctx) {
+		return fmt.Errorf("connection failed initial handshake after %v", initialHandshakeTimeout)
 	}
 
 	for {
@@ -150,7 +154,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		case <-time.After(healthCheckInterval):
 		}
 
-		currentStatus := client.CheckConnection(healthCheckTimeout, ctx)
+		currentStatus := client.CheckConnection(ctx)
 
 		if !currentStatus {
 			log.Println("No longer connected. Attempting to reconnect...")
@@ -159,13 +163,21 @@ func runConnect(cmd *cobra.Command, args []string) error {
 				// currently in an unhealthy state
 				err = client.Connect()
 				if err == nil {
-					log.Println("Reconnected...")
-					break unhealthy_loop
+					// Reconfiguring the peer clears its handshake state, so wait
+					// for the new session to come up before declaring the tunnel
+					// healthy. Reconnecting again here would tear down a handshake
+					// that is still in flight.
+					if client.WaitForHandshake(initialHandshakeTimeout, ctx) {
+						log.Println("Reconnected...")
+						break unhealthy_loop
+					}
+					log.Printf("Reconnected to server, but no handshake within %v", initialHandshakeTimeout)
+				} else {
+					if !lib.IsRecoverableError(err) {
+						return fmt.Errorf("unrecoverable connection error: %w", err)
+					}
+					log.Printf("Failed to reconnect: %v", err)
 				}
-				if !lib.IsRecoverableError(err) {
-					return fmt.Errorf("unrecoverable connection error: %w", err)
-				}
-				log.Printf("Failed to reconnect: %v", err)
 				select {
 				case <-ctx.Done():
 					log.Println("Context is Done; received SIGINT or SIGTERM. Breaking out of unhealthy_loop.")

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -23,9 +23,6 @@ import (
 // (note that this dosen't include the time spent checking)
 const healthCheckInterval = 2 * time.Second
 
-// how long do we wait for the tunnel's first handshake before giving up?
-// Keep this higher than WireGuard's REKEY_TIMEOUT (5s) to allow for retries.
-const initialHandshakeTimeout = 12 * time.Second
 const reconnectInterval = 2 * time.Second // when we're unhealthy, how frequently do we try reconnecting?
 const dialRetryTimeout = 10 * time.Second // how long to retry on ECONNREFUSED
 
@@ -126,7 +123,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	}
 	defer client.DeleteInterface()
 
-	err = client.Connect()
+	err = client.Connect(ctx)
 	if err != nil {
 		return err
 	}
@@ -139,9 +136,6 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	}()
 
 	log.Println("Connected...")
-	if !client.WaitForHandshake(initialHandshakeTimeout, ctx) {
-		return fmt.Errorf("connection failed initial healthcheck after %v", initialHandshakeTimeout)
-	}
 
 	for {
 		// currently in a healthy state
@@ -159,23 +153,15 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		unhealthy_loop:
 			for {
 				// currently in an unhealthy state
-				err = client.Connect()
+				err = client.Connect(ctx)
 				if err == nil {
-					// Reconfiguring the peer clears its handshake state, so wait
-					// for the new session to come up before declaring the tunnel
-					// healthy. Reconnecting again here would tear down a handshake
-					// that is still in flight.
-					if client.WaitForHandshake(initialHandshakeTimeout, ctx) {
-						log.Println("Reconnected...")
-						break unhealthy_loop
-					}
-					log.Printf("Reconnected to server, but no handshake within %v", initialHandshakeTimeout)
-				} else {
-					if !lib.IsRecoverableError(err) {
-						return fmt.Errorf("unrecoverable connection error: %w", err)
-					}
-					log.Printf("Failed to reconnect: %v", err)
+					log.Println("Reconnected...")
+					break unhealthy_loop
 				}
+				if !lib.IsRecoverableError(err) {
+					return fmt.Errorf("unrecoverable connection error: %w", err)
+				}
+				log.Printf("Failed to reconnect: %v", err)
 				select {
 				case <-ctx.Done():
 					log.Println("Context is Done; received SIGINT or SIGTERM. Breaking out of unhealthy_loop.")

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -24,10 +24,8 @@ import (
 const healthCheckInterval = 2 * time.Second
 
 // how long do we wait for the tunnel's first handshake before giving up?
-// this spans several of WireGuard's REKEY_TIMEOUT (5s) handshake retries, so
-// that a single dropped handshake packet doesn't fail the connection.
-const initialHandshakeTimeout = 20 * time.Second
-
+// Keep this higher than WireGuard's REKEY_TIMEOUT (5s) to allow for retries.
+const initialHandshakeTimeout = 12 * time.Second
 const reconnectInterval = 2 * time.Second // when we're unhealthy, how frequently do we try reconnecting?
 const dialRetryTimeout = 10 * time.Second // how long to retry on ECONNREFUSED
 
@@ -142,7 +140,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 
 	log.Println("Connected...")
 	if !client.WaitForHandshake(initialHandshakeTimeout, ctx) {
-		return fmt.Errorf("connection failed initial handshake after %v", initialHandshakeTimeout)
+		return fmt.Errorf("connection failed initial healthcheck after %v", initialHandshakeTimeout)
 	}
 
 	for {

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.12
 	github.com/coreos/go-iptables v0.8.0
 	github.com/fatih/color v1.17.0
-	github.com/prometheus-community/pro-bing v0.7.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.0
+	golang.org/x/net v0.43.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
 )
 
@@ -23,7 +23,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -41,7 +40,6 @@ require (
 	github.com/vishvananda/netns v0.0.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
@@ -49,8 +47,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prometheus-community/pro-bing v0.7.0 h1:KFYFbxC2f2Fp6c+TyxbCOEarf7rbnzr9Gw8eIb0RfZA=
-github.com/prometheus-community/pro-bing v0.7.0/go.mod h1:Moob9dvlY50Bfq6i88xIwfyw7xLFHH69LUgx9n5zqCE=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/lib/client.go
+++ b/lib/client.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -67,18 +66,8 @@ type Client struct {
 	// wgCidr is the current subnet assigned to the WireGuard interface, if any.
 	wgCidr netip.Prefix
 
-	// serverKey is the public key of the server peer, used to locate it among
-	// the interface's peers when reading connection health from the kernel.
-	serverKey wgtypes.Key
-
-	// tunnelSelf and tunnelPeer are our address and the server's address
-	// inside the tunnel.
-	tunnelSelf netip.Addr
-	tunnelPeer netip.Addr
-
-	// Liveness state, reset whenever the peer is reconfigured.
+	// lastRxBytes is the peer's receive counter as of the last health check.
 	lastRxBytes int64
-	probeSeq    int
 }
 
 // CreateInterface creates a new interface for wireguard. DeleteInterface() needs
@@ -127,10 +116,6 @@ func (c *Client) updateInterface(resp connectResponse) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse assigned address %v: %v", resp.AssignedAddr, err)
 	}
-
-	// The vprox server always sits at the first usable address in the subnet.
-	c.tunnelSelf = cidr.Addr()
-	c.tunnelPeer = cidr.Masked().Addr().Next()
 
 	if cidr != c.wgCidr {
 		link := c.link()
@@ -208,8 +193,6 @@ func (c *Client) configureWireguard(connectionResponse connectResponse) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse server public key: %v", err)
 	}
-
-	c.serverKey = serverPublicKey
 
 	// Replacing the peer resets its counters and handshake state, so the
 	// liveness tracking has to start over with it.
@@ -292,54 +275,33 @@ func (c *Client) link() *linkWireguard {
 	return &linkWireguard{LinkAttrs: netlink.LinkAttrs{Name: c.Ifname}}
 }
 
-// SessionExpiry bounds how stale the last handshake may be before the
-// connection is considered dead.
-//
-// WireGuard refuses to use a session older than REJECT_AFTER_TIME (180s), and
-// a peer with traffic to send rekeys once the session passes REKEY_AFTER_TIME
-// (120s). Because we configure a persistent keepalive there is always traffic
-// to send, so a healthy peer's last handshake never ages much beyond 120s.
-const SessionExpiry = 180 * time.Second
+// Tunnel health is judged against WireGuard's own timers. A peer with traffic
+// to send, which the persistent keepalive guarantees, rekeys at
+// REKEY_AFTER_TIME (120s), so a healthy handshake never ages far beyond that.
+const (
+	SessionExpiry            = 180 * time.Second      // REJECT_AFTER_TIME
+	LivenessProbeTimeout     = 500 * time.Millisecond // replies arrive in ~100ms
+	LivenessFailureThreshold = 4                      // one lost packet must not force a reconnect
+	handshakePollInterval    = 100 * time.Millisecond
+)
 
-// handshakePollInterval is how often the kernel is polled while waiting for the
-// first handshake to land.
-const handshakePollInterval = 100 * time.Millisecond
-
-// LivenessProbeTimeout is how long to wait for a probe reply before probing
-// again. Replies on an established tunnel arrive in about 100ms, so this leaves
-// several times the headroom needed for a cross-region path.
-const LivenessProbeTimeout = 500 * time.Millisecond
-
-// LivenessFailureThreshold is how many probes in a row must go unanswered
-// before the tunnel is declared dead. Several are required because isolated
-// packet loss must not tear down a working session: reconnecting replaces the
-// peer and discards a perfectly good handshake.
-const LivenessFailureThreshold = 4
-
-// serverPeer returns the kernel's view of the server peer on our interface.
+// serverPeer returns the kernel's view of the server, the interface's only peer.
 func (c *Client) serverPeer() (wgtypes.Peer, error) {
 	device, err := c.WgClient.Device(c.Ifname)
 	if err != nil {
 		return wgtypes.Peer{}, fmt.Errorf("failed to read wireguard device %v: %v", c.Ifname, err)
 	}
-	for _, peer := range device.Peers {
-		if peer.PublicKey == c.serverKey {
-			return peer, nil
-		}
+	if len(device.Peers) != 1 {
+		return wgtypes.Peer{}, fmt.Errorf("expected one peer on %v, found %v", c.Ifname, len(device.Peers))
 	}
-	return wgtypes.Peer{}, fmt.Errorf("server peer is not configured on %v", c.Ifname)
+	return device.Peers[0], nil
 }
 
-// CheckConnection reports whether the tunnel is currently carrying traffic.
-//
-// Health comes from the counters the WireGuard kernel module exposes. The
-// server never sends anything unsolicited, though, so a healthy idle tunnel and
-// a tunnel whose peer the server has forgotten look identical until the session
-// ages out around 125s. Rather than wait that out, a tunnel that has gone quiet
-// is probed: each probe is an echo request whose reply is observed as growth in
-// the peer's receive counter, never read from a socket.
-//
-// Any traffic at all satisfies the check, so a busy tunnel is never probed.
+// CheckConnection reports whether the tunnel is carrying traffic, using the
+// counters the WireGuard kernel module exposes. The server sends nothing
+// unsolicited, so a healthy idle tunnel is indistinguishable from one whose
+// peer it has forgotten until the session ages out around 125s; a tunnel that
+// has gone quiet is therefore probed rather than waited out.
 func (c *Client) CheckConnection(cancelCtx context.Context) bool {
 	peer, err := c.serverPeer()
 	if err != nil {
@@ -349,17 +311,16 @@ func (c *Client) CheckConnection(cancelCtx context.Context) bool {
 	if peer.LastHandshakeTime.IsZero() {
 		return false
 	}
-	// WireGuard refuses to use a session this old, so no probe could succeed.
+	// No probe could succeed once WireGuard refuses to use the session.
 	if time.Since(peer.LastHandshakeTime) > SessionExpiry {
 		return false
 	}
+	// Any traffic at all proves the tunnel works, so a busy one is never probed.
 	if peer.ReceiveBytes > c.lastRxBytes {
 		c.lastRxBytes = peer.ReceiveBytes
 		return true
 	}
 
-	// The tunnel has been quiet since the last check. Establish whether the far
-	// side is still answering before declaring it dead.
 	for i := 0; i < LivenessFailureThreshold; i++ {
 		if err := c.sendLivenessProbe(); err != nil {
 			log.Printf("healthcheck: failed to send liveness probe: %v", err)
@@ -384,43 +345,37 @@ func (c *Client) CheckConnection(cancelCtx context.Context) bool {
 	return false
 }
 
-// sendLivenessProbe emits a single echo request to the server's tunnel address.
-// The reply is never read: it is observed as growth in the peer's receive
-// counter on the next health check, which keeps this non-blocking.
+// sendLivenessProbe emits one echo request to the server's tunnel address. The
+// reply is never read; it is observed as growth in the peer's receive counter.
 func (c *Client) sendLivenessProbe() error {
-	if !c.tunnelPeer.IsValid() || !c.tunnelSelf.IsValid() {
-		return fmt.Errorf("tunnel addresses are not configured")
+	if !c.wgCidr.IsValid() {
+		return fmt.Errorf("no address is assigned to %v", c.Ifname)
 	}
+	// The vprox server always sits at the first usable address in the subnet.
+	peerAddr := c.wgCidr.Masked().Addr().Next()
 
-	conn, err := icmp.ListenPacket("ip4:icmp", c.tunnelSelf.String())
+	conn, err := icmp.ListenPacket("ip4:icmp", c.wgCidr.Addr().String())
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
 
-	c.probeSeq++
-	msg := icmp.Message{
+	// Identifier and sequence go unset; there is no reply to correlate them with.
+	buf, err := (&icmp.Message{
 		Type: ipv4.ICMPTypeEcho,
-		Body: &icmp.Echo{
-			ID:   os.Getpid() & 0xffff,
-			Seq:  c.probeSeq & 0xffff,
-			Data: []byte("vprox"),
-		},
-	}
-	buf, err := msg.Marshal(nil)
+		Body: &icmp.Echo{Data: []byte("vprox")},
+	}).Marshal(nil)
 	if err != nil {
 		return err
 	}
-	_, err = conn.WriteTo(buf, &net.IPAddr{IP: net.IP(c.tunnelPeer.AsSlice())})
+	_, err = conn.WriteTo(buf, &net.IPAddr{IP: net.IP(peerAddr.AsSlice())})
 	return err
 }
 
 // WaitForHandshake blocks until the tunnel completes its first handshake, the
-// timeout expires, or the context is cancelled.
-//
-// A handshake initiation that is lost in transit is not retried by WireGuard
-// until REKEY_TIMEOUT (5s), so the timeout must span several of those retries
-// for a single dropped packet not to fail the connection.
+// timeout expires, or the context is cancelled. WireGuard does not retry a lost
+// handshake initiation until REKEY_TIMEOUT (5s), so the timeout must span
+// several of those retries for one dropped packet not to fail the connection.
 func (c *Client) WaitForHandshake(timeout time.Duration, cancelCtx context.Context) bool {
 	deadline := time.Now().Add(timeout)
 	for {

--- a/lib/client.go
+++ b/lib/client.go
@@ -12,10 +12,12 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os"
 	"time"
 
-	probing "github.com/prometheus-community/pro-bing"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
@@ -64,6 +66,19 @@ type Client struct {
 
 	// wgCidr is the current subnet assigned to the WireGuard interface, if any.
 	wgCidr netip.Prefix
+
+	// serverKey is the public key of the server peer, used to locate it among
+	// the interface's peers when reading connection health from the kernel.
+	serverKey wgtypes.Key
+
+	// tunnelSelf and tunnelPeer are our address and the server's address
+	// inside the tunnel.
+	tunnelSelf netip.Addr
+	tunnelPeer netip.Addr
+
+	// Liveness state, reset whenever the peer is reconfigured.
+	lastRxBytes int64
+	probeSeq    int
 }
 
 // CreateInterface creates a new interface for wireguard. DeleteInterface() needs
@@ -112,6 +127,10 @@ func (c *Client) updateInterface(resp connectResponse) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse assigned address %v: %v", resp.AssignedAddr, err)
 	}
+
+	// The vprox server always sits at the first usable address in the subnet.
+	c.tunnelSelf = cidr.Addr()
+	c.tunnelPeer = cidr.Masked().Addr().Next()
 
 	if cidr != c.wgCidr {
 		link := c.link()
@@ -190,6 +209,12 @@ func (c *Client) configureWireguard(connectionResponse connectResponse) error {
 		return fmt.Errorf("failed to parse server public key: %v", err)
 	}
 
+	c.serverKey = serverPublicKey
+
+	// Replacing the peer resets its counters and handshake state, so the
+	// liveness tracking has to start over with it.
+	c.lastRxBytes = 0
+
 	keepalive := 25 * time.Second
 	return c.WgClient.ConfigureDevice(c.Ifname, wgtypes.Config{
 		PrivateKey:   &c.Key,
@@ -267,28 +292,152 @@ func (c *Client) link() *linkWireguard {
 	return &linkWireguard{LinkAttrs: netlink.LinkAttrs{Name: c.Ifname}}
 }
 
-// CheckConnection checks the status of the connection with the wireguard peer,
-// and returns true if it is healthy. This sends 3 pings in succession, and blocks
-// until they receive a response or the timeout passes.
-func (c *Client) CheckConnection(timeout time.Duration, cancelCtx context.Context) bool {
-	pinger, err := probing.NewPinger(c.wgCidr.Masked().Addr().Next().String())
+// SessionExpiry bounds how stale the last handshake may be before the
+// connection is considered dead.
+//
+// WireGuard refuses to use a session older than REJECT_AFTER_TIME (180s), and
+// a peer with traffic to send rekeys once the session passes REKEY_AFTER_TIME
+// (120s). Because we configure a persistent keepalive there is always traffic
+// to send, so a healthy peer's last handshake never ages much beyond 120s.
+const SessionExpiry = 180 * time.Second
+
+// handshakePollInterval is how often the kernel is polled while waiting for the
+// first handshake to land.
+const handshakePollInterval = 100 * time.Millisecond
+
+// LivenessProbeTimeout is how long to wait for a probe reply before probing
+// again. Replies on an established tunnel arrive in about 100ms, so this leaves
+// several times the headroom needed for a cross-region path.
+const LivenessProbeTimeout = 500 * time.Millisecond
+
+// LivenessFailureThreshold is how many probes in a row must go unanswered
+// before the tunnel is declared dead. Several are required because isolated
+// packet loss must not tear down a working session: reconnecting replaces the
+// peer and discards a perfectly good handshake.
+const LivenessFailureThreshold = 4
+
+// serverPeer returns the kernel's view of the server peer on our interface.
+func (c *Client) serverPeer() (wgtypes.Peer, error) {
+	device, err := c.WgClient.Device(c.Ifname)
 	if err != nil {
-		log.Printf("error creating pinger: %v", err)
+		return wgtypes.Peer{}, fmt.Errorf("failed to read wireguard device %v: %v", c.Ifname, err)
+	}
+	for _, peer := range device.Peers {
+		if peer.PublicKey == c.serverKey {
+			return peer, nil
+		}
+	}
+	return wgtypes.Peer{}, fmt.Errorf("server peer is not configured on %v", c.Ifname)
+}
+
+// CheckConnection reports whether the tunnel is currently carrying traffic.
+//
+// Health comes from the counters the WireGuard kernel module exposes. The
+// server never sends anything unsolicited, though, so a healthy idle tunnel and
+// a tunnel whose peer the server has forgotten look identical until the session
+// ages out around 125s. Rather than wait that out, a tunnel that has gone quiet
+// is probed: each probe is an echo request whose reply is observed as growth in
+// the peer's receive counter, never read from a socket.
+//
+// Any traffic at all satisfies the check, so a busy tunnel is never probed.
+func (c *Client) CheckConnection(cancelCtx context.Context) bool {
+	peer, err := c.serverPeer()
+	if err != nil {
+		log.Printf("healthcheck: %v", err)
 		return false
+	}
+	if peer.LastHandshakeTime.IsZero() {
+		return false
+	}
+	// WireGuard refuses to use a session this old, so no probe could succeed.
+	if time.Since(peer.LastHandshakeTime) > SessionExpiry {
+		return false
+	}
+	if peer.ReceiveBytes > c.lastRxBytes {
+		c.lastRxBytes = peer.ReceiveBytes
+		return true
 	}
 
-	pinger.InterfaceName = c.Ifname
-	pinger.Timeout = timeout
-	pinger.Count = 3
-	pinger.Interval = 10 * time.Millisecond // Send approximately all at once
-	err = pinger.RunWithContext(cancelCtx)  // Blocks until finished.
+	// The tunnel has been quiet since the last check. Establish whether the far
+	// side is still answering before declaring it dead.
+	for i := 0; i < LivenessFailureThreshold; i++ {
+		if err := c.sendLivenessProbe(); err != nil {
+			log.Printf("healthcheck: failed to send liveness probe: %v", err)
+		}
+
+		select {
+		case <-cancelCtx.Done():
+			return false
+		case <-time.After(LivenessProbeTimeout):
+		}
+
+		peer, err := c.serverPeer()
+		if err != nil {
+			log.Printf("healthcheck: %v", err)
+			return false
+		}
+		if peer.ReceiveBytes > c.lastRxBytes {
+			c.lastRxBytes = peer.ReceiveBytes
+			return true
+		}
+	}
+	return false
+}
+
+// sendLivenessProbe emits a single echo request to the server's tunnel address.
+// The reply is never read: it is observed as growth in the peer's receive
+// counter on the next health check, which keeps this non-blocking.
+func (c *Client) sendLivenessProbe() error {
+	if !c.tunnelPeer.IsValid() || !c.tunnelSelf.IsValid() {
+		return fmt.Errorf("tunnel addresses are not configured")
+	}
+
+	conn, err := icmp.ListenPacket("ip4:icmp", c.tunnelSelf.String())
 	if err != nil {
-		log.Printf("error running pinger: %v", err)
-		return false
+		return err
 	}
-	stats := pinger.Statistics()
-	if stats.PacketsRecv > 0 && stats.PacketsRecv < stats.PacketsSent {
-		log.Printf("warning: %v of %v packets in ping were dropped", stats.PacketsSent-stats.PacketsRecv, stats.PacketsSent)
+	defer conn.Close()
+
+	c.probeSeq++
+	msg := icmp.Message{
+		Type: ipv4.ICMPTypeEcho,
+		Body: &icmp.Echo{
+			ID:   os.Getpid() & 0xffff,
+			Seq:  c.probeSeq & 0xffff,
+			Data: []byte("vprox"),
+		},
 	}
-	return stats.PacketsRecv > 0
+	buf, err := msg.Marshal(nil)
+	if err != nil {
+		return err
+	}
+	_, err = conn.WriteTo(buf, &net.IPAddr{IP: net.IP(c.tunnelPeer.AsSlice())})
+	return err
+}
+
+// WaitForHandshake blocks until the tunnel completes its first handshake, the
+// timeout expires, or the context is cancelled.
+//
+// A handshake initiation that is lost in transit is not retried by WireGuard
+// until REKEY_TIMEOUT (5s), so the timeout must span several of those retries
+// for a single dropped packet not to fail the connection.
+func (c *Client) WaitForHandshake(timeout time.Duration, cancelCtx context.Context) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		peer, err := c.serverPeer()
+		if err != nil {
+			log.Printf("waiting for handshake: %v", err)
+		} else if !peer.LastHandshakeTime.IsZero() {
+			return true
+		}
+
+		if time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-cancelCtx.Done():
+			return false
+		case <-time.After(handshakePollInterval):
+		}
+	}
 }

--- a/lib/client.go
+++ b/lib/client.go
@@ -112,6 +112,11 @@ func (c *Client) Connect(cancelCtx context.Context) error {
 	// Configuring the peer discards any session it already had, so the tunnel
 	// carries nothing until a new handshake completes.
 	if !c.waitForHandshake(cancelCtx) {
+		// The server is holding a peer and a subnet IP for us. Hand them back
+		// now rather than leaving them to the idle timeout.
+		if err := c.Disconnect(); err != nil {
+			log.Printf("warning: failed to disconnect after handshake timed out: %v", err)
+		}
 		return fmt.Errorf("no handshake with server within %v", handshakeTimeout)
 	}
 

--- a/lib/client.go
+++ b/lib/client.go
@@ -83,9 +83,11 @@ func (c *Client) CreateInterface() error {
 	return nil
 }
 
-// Connect attempts to reconnect to the peer. A network interface needs to
-// have already been created with CreateInterface() before calling Connect()
-func (c *Client) Connect() error {
+// Connect attempts to (re)connect to the peer. A network interface needs to
+// have already been created with CreateInterface() before calling Connect().
+//
+// This returns after the WireGuard tunnel handshake is complete.
+func (c *Client) Connect(cancelCtx context.Context) error {
 	resp, err := c.sendConnectionRequest()
 	if err != nil {
 		return err
@@ -105,6 +107,12 @@ func (c *Client) Connect() error {
 	err = c.configureWireguard(resp)
 	if err != nil {
 		return fmt.Errorf("error configuring wireguard interface: %v", err)
+	}
+
+	// Configuring the peer discards any session it already had, so the tunnel
+	// carries nothing until a new handshake completes.
+	if !c.waitForHandshake(cancelCtx) {
+		return fmt.Errorf("no handshake with server within %v", handshakeTimeout)
 	}
 
 	return nil
@@ -275,14 +283,19 @@ func (c *Client) link() *linkWireguard {
 	return &linkWireguard{LinkAttrs: netlink.LinkAttrs{Name: c.Ifname}}
 }
 
-// Tunnel health is judged against WireGuard's own timers. A peer with traffic
-// to send, which the persistent keepalive guarantees, rekeys at
-// REKEY_AFTER_TIME (120s), so a healthy handshake never ages far beyond that.
 const (
-	SessionExpiry            = 180 * time.Second      // REJECT_AFTER_TIME
-	LivenessProbeTimeout     = 500 * time.Millisecond // replies arrive in ~100ms
-	LivenessFailureThreshold = 4                      // one lost packet must not force a reconnect
-	handshakePollInterval    = 100 * time.Millisecond
+	// WireGuard refuses to use a session older than REJECT_AFTER_TIME=180s.
+	// A last handshake time older than this means the tunnel is closed.
+	sessionExpiry = 180 * time.Second
+	// How long to wait before checking whether a liveness probe was answered.
+	// Replies on an established tunnel arrive in about 100ms.
+	livenessProbeResponseWait = 500 * time.Millisecond
+	// How many unanswered probes to tolerate before declaring the tunnel dead.
+	livenessFailureThreshold = 4
+	// How long to wait for the tunnel's first handshake. This should be higher
+	// than the REKEY_TIMEOUT=5s that WireGuard uses to retry handshakes.
+	handshakeTimeout      = 12 * time.Second
+	handshakePollInterval = 100 * time.Millisecond
 )
 
 // serverPeer returns the kernel's view of the server, the interface's only peer.
@@ -297,11 +310,8 @@ func (c *Client) serverPeer() (wgtypes.Peer, error) {
 	return device.Peers[0], nil
 }
 
-// CheckConnection reports whether the tunnel is carrying traffic, using the
-// counters the WireGuard kernel module exposes. The server sends nothing
-// unsolicited, so a healthy idle tunnel is indistinguishable from one whose
-// peer it has forgotten until the session ages out around 125s; a tunnel that
-// has gone quiet is therefore probed rather than waited out.
+// CheckConnection reports whether the tunnel is carrying traffic, judged from
+// the counters the WireGuard kernel module exposes.
 func (c *Client) CheckConnection(cancelCtx context.Context) bool {
 	peer, err := c.serverPeer()
 	if err != nil {
@@ -312,7 +322,7 @@ func (c *Client) CheckConnection(cancelCtx context.Context) bool {
 		return false
 	}
 	// No probe could succeed once WireGuard refuses to use the session.
-	if time.Since(peer.LastHandshakeTime) > SessionExpiry {
+	if time.Since(peer.LastHandshakeTime) > sessionExpiry {
 		return false
 	}
 	// Any traffic at all proves the tunnel works, so a busy one is never probed.
@@ -321,15 +331,17 @@ func (c *Client) CheckConnection(cancelCtx context.Context) bool {
 		return true
 	}
 
-	for i := 0; i < LivenessFailureThreshold; i++ {
-		if err := c.sendLivenessProbe(); err != nil {
+	// The server doesn't send any keepalives, so zero rx bytes might just mean an
+	// idle tunnel. We probe to confirm/deny this.
+	for i := 0; i < livenessFailureThreshold; i++ {
+		if err := c.fireAndForgetLivenessProbe(); err != nil {
 			log.Printf("healthcheck: failed to send liveness probe: %v", err)
 		}
 
 		select {
 		case <-cancelCtx.Done():
 			return false
-		case <-time.After(LivenessProbeTimeout):
+		case <-time.After(livenessProbeResponseWait):
 		}
 
 		peer, err := c.serverPeer()
@@ -345,9 +357,9 @@ func (c *Client) CheckConnection(cancelCtx context.Context) bool {
 	return false
 }
 
-// sendLivenessProbe emits one echo request to the server's tunnel address. The
-// reply is never read; it is observed as growth in the peer's receive counter.
-func (c *Client) sendLivenessProbe() error {
+// fireAndForgetLivenessProbe emits one echo request to the server's tunnel
+// address, returning immediately. This should trigger rxBytes growth on reply.
+func (c *Client) fireAndForgetLivenessProbe() error {
 	if !c.wgCidr.IsValid() {
 		return fmt.Errorf("no address is assigned to %v", c.Ifname)
 	}
@@ -372,12 +384,10 @@ func (c *Client) sendLivenessProbe() error {
 	return err
 }
 
-// WaitForHandshake blocks until the tunnel completes its first handshake, the
-// timeout expires, or the context is cancelled. WireGuard does not retry a lost
-// handshake initiation until REKEY_TIMEOUT (5s), so the timeout must span
-// several of those retries for one dropped packet not to fail the connection.
-func (c *Client) WaitForHandshake(timeout time.Duration, cancelCtx context.Context) bool {
-	deadline := time.Now().Add(timeout)
+// waitForHandshake blocks until the tunnel completes a handshake, the timeout
+// expires, or the context is cancelled.
+func (c *Client) waitForHandshake(cancelCtx context.Context) bool {
+	deadline := time.Now().Add(handshakeTimeout)
 	for {
 		peer, err := c.serverPeer()
 		if err != nil {


### PR DESCRIPTION
The initial healthcheck sent three pings 10ms apart and then waited out a 5s timeout, so it was a single probe burst at t=0 rather than 5s of probing.

Connect now waits up to 20s for the first handshake, polling the state the kernel already exposes. Steady-state health reads the peer's receive counter instead of pinging. A tunnel that has gone quiet is probed with echo requests whose replies are observed as counter growth rather than read from a socket, four times at 500ms apart before it is declared dead. Any real traffic satisfies the check, so an active tunnel is never probed.

Reconnecting now waits for the new session to come up.

Measured against a v1.0.10 server: a forgotten peer is detected and recovered in 2.6-3.6s, and an idle tunnel costs 32 B/s in each direction, about a third of the traffic the previous ping check used.