### PR TITLE
Restrict healthcheck oif via BINDTODEVICE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.0
 	golang.org/x/net v0.43.0
+	golang.org/x/sys v0.35.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
 )
 
@@ -41,7 +42,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
-	golang.org/x/sys v0.35.0 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/lib/client.go
+++ b/lib/client.go
@@ -12,11 +12,13 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"syscall"
 	"time"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
+	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
@@ -371,7 +373,20 @@ func (c *Client) fireAndForgetLivenessProbe() error {
 	// The vprox server always sits at the first usable address in the subnet.
 	peerAddr := c.wgCidr.Masked().Addr().Next()
 
-	conn, err := icmp.ListenPacket("ip4:icmp", c.wgCidr.Addr().String())
+	// Since a host can hold several tunnels to the same server, we need this
+	// ping to unambiguously identify the tunnel we're measuring by interface.
+	lc := net.ListenConfig{
+		Control: func(_, _ string, rawConn syscall.RawConn) error {
+			var sockErr error
+			if err := rawConn.Control(func(fd uintptr) {
+				sockErr = unix.SetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_BINDTODEVICE, c.Ifname)
+			}); err != nil {
+				return err
+			}
+			return sockErr
+		},
+	}
+	conn, err := lc.ListenPacket(context.Background(), "ip4:icmp", c.wgCidr.Addr().String())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This resolves an unambiguity introduced in `1.0.11` if one host has multiple tunnels to the same host.