### PR TITLE
Filter internet-scanner noise from control-plane HTTP error log

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -761,6 +762,11 @@ func (srv *Server) ListenForHttps() error {
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
 		},
+		// The control plane listens on the public internet, so its :443 socket
+		// is constantly hit by port scanners and bots. Their failed TLS
+		// handshakes and malformed HTTP/2 prefaces would otherwise be logged as
+		// errors by net/http's default logger. Filter that noise out here.
+		ErrorLog: log.New(scannerNoiseFilter{}, "", log.LstdFlags),
 	}
 
 	listener, err := net.Listen("tcp", fmt.Sprintf("%v:443", srv.BindAddr))
@@ -786,6 +792,30 @@ func (srv *Server) ListenForHttps() error {
 	case err = <-errCh:
 		return err
 	}
+}
+
+// scannerNoiseSubstrings are markers of net/http server error-log lines that
+// are produced by internet scanners rather than real server faults. They are
+// dropped by scannerNoiseFilter.
+var scannerNoiseSubstrings = []string{
+	// e.g. "http: TLS handshake error from 1.2.3.4:5678: ..."
+	"TLS handshake error",
+	// e.g. "http2: server: error reading preface from client 1.2.3.4:5678: ..."
+	"error reading preface from client",
+}
+
+// scannerNoiseFilter is an io.Writer for http.Server.ErrorLog that discards
+// scanner-generated noise (see scannerNoiseSubstrings) and forwards everything
+// else to stderr, matching the default net/http logging destination.
+type scannerNoiseFilter struct{}
+
+func (scannerNoiseFilter) Write(p []byte) (int, error) {
+	for _, s := range scannerNoiseSubstrings {
+		if strings.Contains(string(p), s) {
+			return len(p), nil
+		}
+	}
+	return os.Stderr.Write(p)
 }
 
 //go:embed certs/cert.pem certs/key.pem


### PR DESCRIPTION
## Summary
The control plane listens on public `:443` (`net.Listen("tcp", ":443")` in `lib/server.go`), so its socket is constantly hit by internet port scanners and bots. Their failed TLS handshakes and malformed HTTP/2 prefaces are logged by Go's `net/http` server via `http.Server.ErrorLog`, which — because we never set it — falls back to `log.Default()` → stderr. In Datadog (`source:vprox`) these dominate the "error"-looking volume: ~1.88M `http: TLS handshake error from <ip>: ...` lines and ~800 `http2: server: error reading preface from client <ip>: ...` lines over 7 days. None are real server faults.

This wires `http.Server.ErrorLog` to a filtering `io.Writer` that drops those two line categories and forwards everything else to stderr (same destination/format as before, `LstdFlags`):

```go
var scannerNoiseSubstrings = []string{
    "TLS handshake error",              // "http: TLS handshake error from 1.2.3.4:5678: ..."
    "error reading preface from client", // "http2: server: error reading preface from client ..."
}

type scannerNoiseFilter struct{}
func (scannerNoiseFilter) Write(p []byte) (int, error) {
    for _, s := range scannerNoiseSubstrings {
        if strings.Contains(string(p), s) { return len(p), nil } // drop
    }
    return os.Stderr.Write(p)
}

httpServer := &http.Server{
    ...
    ErrorLog: log.New(scannerNoiseFilter{}, "", log.LstdFlags),
}
```

Minimal and scoped: no change to vprox's own `log.Printf` call sites and no behavior change for any non-scanner log line. `go build ./...`, `go vet ./...`, `go test ./...`, and `gofmt` all pass.

## Context / analysis
vprox currently has **no log levels** — everything is stdlib `log.Printf` at one undifferentiated severity, which is why Datadog classifies it all as `status:info`. The scanner lines are the highest-volume "errors" yet aren't emitted by vprox's own logger at all; they come from the stdlib http server, so this `ErrorLog` hook is the correct place to control them.

## Alternatives (intentionally NOT in this PR)
- **`log/slog` migration:** introduce a structured leveled logger (stdlib, no new dep vs zap/zerolog) and reclassify these lines as `warn`/`debug` instead of string-filtering, plus confirm the Datadog JSON pipeline maps `level`→`status`. Larger, mechanical, higher review surface — worth doing separately.
- **Datadog exclusion filter (no code):** drop these substrings at ingestion. Instant/reversible and saves indexing cost, but loses per-line scan visibility; pair with an aggregate scan-count metric. Complementary to this change.

Draft for review of the approach/substring list before merge.

Link to Devin session: https://modal.devinenterprise.com/sessions/a2093159c7e541998fbd2fd1c877f3f8
Requested by: @saltzm