### PR TITLE
Revert client-side healthcheck and timeout changes (#23, #24, #25)

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -23,8 +23,9 @@ import (
 // (note that this dosen't include the time spent checking)
 const healthCheckInterval = 2 * time.Second
 
-const reconnectInterval = 2 * time.Second // when we're unhealthy, how frequently do we try reconnecting?
-const dialRetryTimeout = 10 * time.Second // how long to retry on ECONNREFUSED
+const healthCheckTimeout = 5 * time.Second // how long do we wait before the health check times out?
+const reconnectInterval = 2 * time.Second  // when we're unhealthy, how frequently do we try reconnecting?
+const dialRetryTimeout = 10 * time.Second  // how long to retry on ECONNREFUSED
 
 // dialWithRetry retries TCP connections on ECONNREFUSED up to dialRetryTimeout.
 func dialWithRetry(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -123,7 +124,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	}
 	defer client.DeleteInterface()
 
-	err = client.Connect(ctx)
+	err = client.Connect()
 	if err != nil {
 		return err
 	}
@@ -136,6 +137,9 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	}()
 
 	log.Println("Connected...")
+	if !client.CheckConnection(healthCheckTimeout, ctx) {
+		return fmt.Errorf("connection failed initial healthcheck after %v", healthCheckTimeout)
+	}
 
 	for {
 		// currently in a healthy state
@@ -146,14 +150,14 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		case <-time.After(healthCheckInterval):
 		}
 
-		currentStatus := client.CheckConnection(ctx)
+		currentStatus := client.CheckConnection(healthCheckTimeout, ctx)
 
 		if !currentStatus {
 			log.Println("No longer connected. Attempting to reconnect...")
 		unhealthy_loop:
 			for {
 				// currently in an unhealthy state
-				err = client.Connect(ctx)
+				err = client.Connect()
 				if err == nil {
 					log.Println("Reconnected...")
 					break unhealthy_loop

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.12
 	github.com/coreos/go-iptables v0.8.0
 	github.com/fatih/color v1.17.0
+	github.com/prometheus-community/pro-bing v0.7.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.0
-	golang.org/x/net v0.43.0
-	golang.org/x/sys v0.35.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
 )
 
@@ -24,6 +23,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -41,7 +41,9 @@ require (
 	github.com/vishvananda/netns v0.0.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
+	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
@@ -47,6 +49,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus-community/pro-bing v0.7.0 h1:KFYFbxC2f2Fp6c+TyxbCOEarf7rbnzr9Gw8eIb0RfZA=
+github.com/prometheus-community/pro-bing v0.7.0/go.mod h1:Moob9dvlY50Bfq6i88xIwfyw7xLFHH69LUgx9n5zqCE=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/lib/client.go
+++ b/lib/client.go
@@ -12,13 +12,10 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"syscall"
 	"time"
 
+	probing "github.com/prometheus-community/pro-bing"
 	"github.com/vishvananda/netlink"
-	"golang.org/x/net/icmp"
-	"golang.org/x/net/ipv4"
-	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
@@ -67,9 +64,6 @@ type Client struct {
 
 	// wgCidr is the current subnet assigned to the WireGuard interface, if any.
 	wgCidr netip.Prefix
-
-	// lastRxBytes is the peer's receive counter as of the last health check.
-	lastRxBytes int64
 }
 
 // CreateInterface creates a new interface for wireguard. DeleteInterface() needs
@@ -85,11 +79,9 @@ func (c *Client) CreateInterface() error {
 	return nil
 }
 
-// Connect attempts to (re)connect to the peer. A network interface needs to
-// have already been created with CreateInterface() before calling Connect().
-//
-// This returns after the WireGuard tunnel handshake is complete.
-func (c *Client) Connect(cancelCtx context.Context) error {
+// Connect attempts to reconnect to the peer. A network interface needs to
+// have already been created with CreateInterface() before calling Connect()
+func (c *Client) Connect() error {
 	resp, err := c.sendConnectionRequest()
 	if err != nil {
 		return err
@@ -109,17 +101,6 @@ func (c *Client) Connect(cancelCtx context.Context) error {
 	err = c.configureWireguard(resp)
 	if err != nil {
 		return fmt.Errorf("error configuring wireguard interface: %v", err)
-	}
-
-	// Configuring the peer discards any session it already had, so the tunnel
-	// carries nothing until a new handshake completes.
-	if !c.waitForHandshake(cancelCtx) {
-		// The server is holding a peer and a subnet IP for us. Hand them back
-		// now rather than leaving them to the idle timeout.
-		if err := c.Disconnect(); err != nil {
-			log.Printf("warning: failed to disconnect after handshake timed out: %v", err)
-		}
-		return fmt.Errorf("no handshake with server within %v", handshakeTimeout)
 	}
 
 	return nil
@@ -209,10 +190,6 @@ func (c *Client) configureWireguard(connectionResponse connectResponse) error {
 		return fmt.Errorf("failed to parse server public key: %v", err)
 	}
 
-	// Replacing the peer resets its counters and handshake state, so the
-	// liveness tracking has to start over with it.
-	c.lastRxBytes = 0
-
 	keepalive := 25 * time.Second
 	return c.WgClient.ConfigureDevice(c.Ifname, wgtypes.Config{
 		PrivateKey:   &c.Key,
@@ -290,139 +267,28 @@ func (c *Client) link() *linkWireguard {
 	return &linkWireguard{LinkAttrs: netlink.LinkAttrs{Name: c.Ifname}}
 }
 
-const (
-	// WireGuard refuses to use a session older than REJECT_AFTER_TIME=180s.
-	// A last handshake time older than this means the tunnel is closed.
-	sessionExpiry = 180 * time.Second
-	// How long to wait before checking whether a liveness probe was answered.
-	// Replies on an established tunnel arrive in about 100ms.
-	livenessProbeResponseWait = 500 * time.Millisecond
-	// How many unanswered probes to tolerate before declaring the tunnel dead.
-	livenessFailureThreshold = 10
-	// How long to wait for the tunnel's first handshake. This should be higher
-	// than the REKEY_TIMEOUT=5s that WireGuard uses to retry handshakes.
-	handshakeTimeout      = 12 * time.Second
-	handshakePollInterval = 100 * time.Millisecond
-)
-
-// serverPeer returns the kernel's view of the server, the interface's only peer.
-func (c *Client) serverPeer() (wgtypes.Peer, error) {
-	device, err := c.WgClient.Device(c.Ifname)
+// CheckConnection checks the status of the connection with the wireguard peer,
+// and returns true if it is healthy. This sends 3 pings in succession, and blocks
+// until they receive a response or the timeout passes.
+func (c *Client) CheckConnection(timeout time.Duration, cancelCtx context.Context) bool {
+	pinger, err := probing.NewPinger(c.wgCidr.Masked().Addr().Next().String())
 	if err != nil {
-		return wgtypes.Peer{}, fmt.Errorf("failed to read wireguard device %v: %v", c.Ifname, err)
-	}
-	if len(device.Peers) != 1 {
-		return wgtypes.Peer{}, fmt.Errorf("expected one peer on %v, found %v", c.Ifname, len(device.Peers))
-	}
-	return device.Peers[0], nil
-}
-
-// CheckConnection reports whether the tunnel is carrying traffic, judged from
-// the counters the WireGuard kernel module exposes.
-func (c *Client) CheckConnection(cancelCtx context.Context) bool {
-	peer, err := c.serverPeer()
-	if err != nil {
-		log.Printf("healthcheck: %v", err)
+		log.Printf("error creating pinger: %v", err)
 		return false
 	}
-	if peer.LastHandshakeTime.IsZero() {
+
+	pinger.InterfaceName = c.Ifname
+	pinger.Timeout = timeout
+	pinger.Count = 3
+	pinger.Interval = 10 * time.Millisecond // Send approximately all at once
+	err = pinger.RunWithContext(cancelCtx)  // Blocks until finished.
+	if err != nil {
+		log.Printf("error running pinger: %v", err)
 		return false
 	}
-	// No probe could succeed once WireGuard refuses to use the session.
-	if time.Since(peer.LastHandshakeTime) > sessionExpiry {
-		return false
+	stats := pinger.Statistics()
+	if stats.PacketsRecv > 0 && stats.PacketsRecv < stats.PacketsSent {
+		log.Printf("warning: %v of %v packets in ping were dropped", stats.PacketsSent-stats.PacketsRecv, stats.PacketsSent)
 	}
-	// Any traffic at all proves the tunnel works, so a busy one is never probed.
-	if peer.ReceiveBytes > c.lastRxBytes {
-		c.lastRxBytes = peer.ReceiveBytes
-		return true
-	}
-
-	// The server doesn't send any keepalives, so zero rx bytes might just mean an
-	// idle tunnel. We probe to confirm/deny this.
-	for i := 0; i < livenessFailureThreshold; i++ {
-		if err := c.fireAndForgetLivenessProbe(); err != nil {
-			log.Printf("healthcheck: failed to send liveness probe: %v", err)
-		}
-
-		select {
-		case <-cancelCtx.Done():
-			return false
-		case <-time.After(livenessProbeResponseWait):
-		}
-
-		peer, err := c.serverPeer()
-		if err != nil {
-			log.Printf("healthcheck: %v", err)
-			return false
-		}
-		if peer.ReceiveBytes > c.lastRxBytes {
-			c.lastRxBytes = peer.ReceiveBytes
-			return true
-		}
-	}
-	return false
-}
-
-// fireAndForgetLivenessProbe emits one echo request to the server's tunnel
-// address, returning immediately. This should trigger rxBytes growth on reply.
-func (c *Client) fireAndForgetLivenessProbe() error {
-	if !c.wgCidr.IsValid() {
-		return fmt.Errorf("no address is assigned to %v", c.Ifname)
-	}
-	// The vprox server always sits at the first usable address in the subnet.
-	peerAddr := c.wgCidr.Masked().Addr().Next()
-
-	// Since a host can hold several tunnels to the same server, we need this
-	// ping to unambiguously identify the tunnel we're measuring by interface.
-	lc := net.ListenConfig{
-		Control: func(_, _ string, rawConn syscall.RawConn) error {
-			var sockErr error
-			if err := rawConn.Control(func(fd uintptr) {
-				sockErr = unix.SetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_BINDTODEVICE, c.Ifname)
-			}); err != nil {
-				return err
-			}
-			return sockErr
-		},
-	}
-	conn, err := lc.ListenPacket(context.Background(), "ip4:icmp", c.wgCidr.Addr().String())
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	// Identifier and sequence go unset; there is no reply to correlate them with.
-	buf, err := (&icmp.Message{
-		Type: ipv4.ICMPTypeEcho,
-		Body: &icmp.Echo{Data: []byte("vprox")},
-	}).Marshal(nil)
-	if err != nil {
-		return err
-	}
-	_, err = conn.WriteTo(buf, &net.IPAddr{IP: net.IP(peerAddr.AsSlice())})
-	return err
-}
-
-// waitForHandshake blocks until the tunnel completes a handshake, the timeout
-// expires, or the context is cancelled.
-func (c *Client) waitForHandshake(cancelCtx context.Context) bool {
-	deadline := time.Now().Add(handshakeTimeout)
-	for {
-		peer, err := c.serverPeer()
-		if err != nil {
-			log.Printf("waiting for handshake: %v", err)
-		} else if !peer.LastHandshakeTime.IsZero() {
-			return true
-		}
-
-		if time.Now().After(deadline) {
-			return false
-		}
-		select {
-		case <-cancelCtx.Done():
-			return false
-		case <-time.After(handshakePollInterval):
-		}
-	}
+	return stats.PacketsRecv > 0
 }


### PR DESCRIPTION
## Summary

Reverts the three client healthchecking commits, in reverse order:

- 026f95b "Restrict healthcheck oif via BINDTODEVICE" (#25)
- b86df92 "Bump livenessFailureThreshold to match old liveness timeout" (#24)
- 1f4643b "Tighten up client side healthchecking and timeouts" (#23)

Net effect: `lib/client.go` goes back to ICMP ping based liveness (`pro-bing`) instead of deriving health from the WireGuard peer handshake/receive counters, and `cmd/connect.go` returns to the previous connect/retry timing. `go.mod` re-adds `pro-bing` and drops the direct `golang.org/x/net` / `golang.org/x/sys` requirements.

The ECDSA cert change (#26, currently tagged v1.0.14) is untouched.

Verified with `go build ./...`, `go vet ./...`, `go test ./...`, and `go mod tidy` (no diff).


Link to Devin session: https://modal.devinenterprise.com/sessions/79a21579eb1241ca9c7c54bdad7e6562
Requested by: @saltzm